### PR TITLE
Update counter to correct handle local timezone

### DIFF
--- a/public_html/index.shtml
+++ b/public_html/index.shtml
@@ -6,7 +6,16 @@
 
         <script>
             function refresh() {
-                var theBigDay = new Date(2016, 5, 25, 14, 0, 0, 0);
+
+                var theBigDay = new Date();
+                theBigDay.setUTCFullYear(2016);
+                theBigDay.setUTCMonth(5);
+                theBigDay.setUTCDate(25);
+                theBigDay.setUTCHours(13);
+                theBigDay.setUTCMinutes(0);
+                theBigDay.setUTCSeconds(0);
+                theBigDay.setUTCMilliseconds(0);
+                
                 var today = Date.now();
 
                 var days = 0;


### PR DESCRIPTION
Previously, the timezone of 'the big day' defaulted to the local timezone of the browser. It is now set correctly in UTC.
